### PR TITLE
feat: support format raw which accept url as path

### DIFF
--- a/src/components/linktokey.ts
+++ b/src/components/linktokey.ts
@@ -9,6 +9,16 @@ const fetchKeyByUrl: (prefix: string, path: string) => Promise<string> = async (
       method: 'get',
     }).then(body => body.text())
     return defaultKey
+  } else if (prefix === 'raw') {
+    console.log('please ensure the cors rules allow this page')
+    if (!path.startsWith('https')) {
+      console.log('public key should load by https')
+      return '';
+    }
+    const defaultKey = await fetch(path, {
+      method: 'get',
+    }).then(body => body.text())
+    return defaultKey
   }
   return '';
 }

--- a/src/components/linktokey.vue
+++ b/src/components/linktokey.vue
@@ -5,7 +5,7 @@ import encryptid from '@/components/encrypyid.vue';
 import { getOrFetch } from '@/components/cache';
 const props = defineProps<{
   prefix: string,
-  path: string
+  path: string | string[]
 }>()
 
 const { prefix, path } = toRefs(props);
@@ -15,7 +15,12 @@ const ownKey = reactive({ key: '' })
 watchEffect(async () => {
   const prefix_value = prefix.value ?? '';
   const path_value = path.value ?? '';
-  ownKey.key = await (await getOrFetch(prefix_value, path_value)).rawKey;
+  if (prefix_value === 'raw') {
+    const path_values = (path_value as string[]).join('/');
+    ownKey.key = await (await getOrFetch(prefix_value, path_values)).rawKey;
+  } else {
+    ownKey.key = await (await getOrFetch(prefix_value, path_value as string)).rawKey;
+  }
   // api.github.com/
 });
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,7 +7,7 @@ const routes = [
   { path: '', component: App },
   { path: '/', component: App },
   {
-    path: '/:prefix/:path',
+    path: '/:prefix/:path(.*)*',
     component: App,
     props: true
   },


### PR DESCRIPTION
if user know some url have a pure-text key and it's cors policy allow page user can use `/raw/${url}` to start encrypt by it.

fixes #9

- [x] New Information 添加新内容

# Checklist

- [x] Format is Markdown
